### PR TITLE
leaving behind a null

### DIFF
--- a/lib/Block.js
+++ b/lib/Block.js
@@ -5,7 +5,7 @@ function Block(config) {
   
   this.lines      = config.lines || [];
   this.target     = config.target || null;
-  this.indent     = config.indent || null;
+  this.indent     = config.indent || '';
   this.lineNumber = config.lineNumber;
 }
 


### PR DESCRIPTION
in my `gulpfile.js`, i have:

``` js
gulp.task('index', function () {
  return gulp.src('app/index.html')
    .pipe(htmlbuild({
      js: htmlbuild.preprocess.js(function (block) {
        block
          .pipe(gulpSrc())
          .pipe(concat('libraries.js'))
          .pipe(gulp.dest(('app/scripts/'));

        block.end('scripts/libraries.js');
      })
    }))
    .pipe(gulp.dest(prefix('app/')));
});
```

where `gulpSrc` is taken from the example in the docs.

in my `index.html`, i have:

``` html
<!-- htmlbuild:js -->
<script src="bower_components/angular/angular.js"></script>
<script src="bower_components/angular-animate/angular-animate.js"></script>
<script src="bower_components/angular-sanitize/angular-sanitize.js"></script>
<script src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>
<script src="app/scripts/libraries/hmac-sha1.js"></script>
<script src="node_modules/oauth-1.0a/oauth-1.0a.js"></script>
<!-- endbuild -->
```

and when i run the task, i end up with:

``` html
null<script src="scripts/libraries.js"></script>
```

---

where's that leading `null` coming from?
