### PR TITLE
Delete unused deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
   "dependencies": {
     "gulp-util": "~3.0.4",
     "event-stream": "*",
-    "through2": "~0.6.3",
-    "lazy-flatten-stream": "~0.1.0",
     "pause-stream": "0.0.11",
     "stream-stream": "~1.2.6",
     "readable-stream": "~1.1.10"


### PR DESCRIPTION
This PR is to resolve issues installing `gulp-htmlbuild` when using Visual Studio and also referencing later versions of karma. 

Strange combination of issues, but it seems downstream dependencies of `lazy-flatten-stream`  version of `readable-stream` which is referenced directly to `https://github.com/isaacs/readable-stream/archive/master.tar.gz` which causes issues on NPM install. 

Specifically it is from the following dependency tree:

```
gulp-htmlbuild -> 
  lazy-flatten-stream -> 
    proxy-stream -> 
      read-write-stream -> 
        `https://github.com/isaacs/readable-stream/archive/master.tar.gz`
```

Since this package doesn't use it, it would be great if you can republish your package with these dependencies removed.

Cheers! :+1: 
